### PR TITLE
fix preprocessing command with wrong arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ bash commands/data_download.sh
 The command to preprocess passage and document data is listed below:
 
 ```
-python data/msmarco_data.py 
+python data/msmarco_data.py \
 --data_dir $raw_data_dir \
 --out_data_dir $preprocessed_data_dir \ 
---model_type {use rdot_nll_fairseq_fast for SEED-Encoder ANCE FirstP} \ 
+--train_model_type {use rdot_nll_fairseq_fast for SEED-Encoder ANCE FirstP} \ 
 --max_seq_length {use 512 for ANCE FirstP, 2048 for ANCE MaxP} \ 
 --data_type {use 1 for passage, 0 for document}
+--bpe_vocab_file $bpe_vocab_file
 ```
 
 The data preprocessing command is included as the first step in the training command file commands/run_train.sh

--- a/commands/data_download.sh
+++ b/commands/data_download.sh
@@ -41,6 +41,9 @@ gunzip msmarco-docdev-top100.gz
 wget https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-docdev-queries.tsv.gz
 gunzip msmarco-docdev-queries.tsv.gz
 
+wget https://msmarco.blob.core.windows.net/msmarcoranking/msmarco-docdev-qrels.tsv.gz
+gunzip msmarco-docdev-qrels.tsv.gz
+
 
 # clone DPR repo and download NQ and TriviaQA datasets
 cd ../../../


### PR DESCRIPTION
I encountered the error because some arguments doesn't met.
So I fixed model_type to train_model_type and added bpe_vocab_file argument to make script working out of the box.

Error Messages
Traceback (most recent call last):
  File "python3.7/multiprocessing/process.py", line 297
    self.run()
  File "python3.7/multiprocessing/process.py", line 99,
    self._target(*self._args, **self._kwargs)
  File "MSMARCO/SEED-Encoder-main/utils/util.py", line 335, in tokenize_to_file
    tokenizer = BertWordPieceTokenizer(args.bpe_vocab_file, clean_text=False, strip_accents=False, lowercase=False)
  File "python3.7/site-packages/tokenizers/implementati
    tokenizer = Tokenizer(WordPiece(vocab, unk_token=str(unk_token)))
Exception: Error while initializing WordPiece: No such file or directory (os error 2)


